### PR TITLE
Added Minimal Gcp Exporter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,36 @@
+# Ref. https://github.com/github/gitignore/blob/master/C%2B%2B.gitignore
+# Prerequisites
+*.d
+
+# Compiled Object files
+*.slo
+*.lo
+*.o
+*.obj
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Compiled Dynamic libraries
+*.so
+*.dylib
+*.dll
+
+# Fortran module files
+*.mod
+*.smod
+
+# Compiled Static libraries
+*.lai
+*.la
+*.a
+*.lib
+
+# Executables
+*.exe
+*.out
+*.app
+
+# Bazel files
+/bazel-*

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,0 +1,105 @@
+# Copyright 2019, OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+workspace(name = "io_opentelemetry_operations_cpp")
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+#gRPC
+http_archive(
+        name = "com_github_grpc_grpc",
+        strip_prefix = "grpc-master",
+        urls = ["https://github.com/grpc/grpc/archive/master.tar.gz"],
+)
+
+load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
+
+grpc_deps()
+
+# grpc_deps() cannot load() its deps, this WORKSPACE has to do it.
+# See also: https://github.com/bazelbuild/bazel/issues/1943
+load(
+    "@build_bazel_rules_apple//apple:repositories.bzl",
+    "apple_rules_dependencies",
+)
+
+apple_rules_dependencies()
+
+load(
+    "@build_bazel_apple_support//lib:repositories.bzl",
+    "apple_support_dependencies",
+)
+
+apple_support_dependencies()
+
+# OpenTelemetry-cpp
+http_archive(
+        name = "io_opentelemetry_cpp",
+        strip_prefix = "opentelemetry-cpp-master",
+        urls = ["https://github.com/open-telemetry/opentelemetry-cpp/archive/master.zip"],
+)
+
+# Google APIs - used by GCP exporter.
+http_archive(
+    name = "com_google_googleapis",
+    strip_prefix = "googleapis-master",
+    urls = ["https://github.com/googleapis/googleapis/archive/master.zip"],
+)
+
+load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
+
+switched_rules_by_language(
+    name = "com_google_googleapis_imports",
+    cc = True,
+    grpc = True,
+)
+
+# Uses older protobuf version because of
+# https://github.com/protocolbuffers/protobuf/issues/7179
+http_archive(
+    name = "com_google_protobuf",
+    sha256 = "b679cef31102ed8beddc39ecfd6368ee311cbee6f50742f13f21be7278781821",
+    strip_prefix = "protobuf-3.11.2",
+    urls = [
+        "https://github.com/protocolbuffers/protobuf/releases/download/v3.11.2/protobuf-all-3.11.2.tar.gz",
+    ],
+)
+
+load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
+
+protobuf_deps()
+
+new_local_repository(
+    name = "com_github_opentelemetry_proto",
+    build_file = "//bazel:opentelemetry_proto.BUILD",
+    path = "third_party/opentelemetry-proto",
+)
+
+# GoogleTest framework.
+# Only needed for tests, not to build the OpenTelemetry library.
+http_archive(
+    name = "com_google_googletest",
+    sha256 = "9dc9157a9a1551ec7a7e43daea9a694a0bb5fb8bec81235d8a1e6ef64c716dcb",
+    strip_prefix = "googletest-release-1.10.0",
+    urls = ["https://github.com/google/googletest/archive/release-1.10.0.tar.gz"],
+)
+
+# Google Benchmark library.
+# Only needed for benchmarks, not to build the OpenTelemetry library.
+http_archive(
+    name = "com_github_google_benchmark",
+    sha256 = "3c6a165b6ecc948967a1ead710d4a181d7b0fbcaa183ef7ea84604994966221a",
+    strip_prefix = "benchmark-1.5.0",
+    urls = ["https://github.com/google/benchmark/archive/v1.5.0.tar.gz"],
+)

--- a/examples/trace/gcp_exporter/BUILD
+++ b/examples/trace/gcp_exporter/BUILD
@@ -1,0 +1,25 @@
+cc_library(
+    name = "foo_library",
+    srcs = [
+        "foo_library/foo_library.cc",
+    ],
+    hdrs = [
+        "foo_library/foo_library.h",
+    ],
+    deps = [
+        "@io_opentelemetry_cpp//api",
+    ],
+)
+
+cc_binary(
+    name = "example_simple",
+    srcs = [
+        "main.cc",
+    ],
+    deps = [
+        ":foo_library",
+        "//exporters/trace/gcp_exporter:gcp_exporter",
+        "@io_opentelemetry_cpp//api",
+        "@io_opentelemetry_cpp//sdk/src/trace",
+    ],
+)

--- a/examples/trace/gcp_exporter/README.md
+++ b/examples/trace/gcp_exporter/README.md
@@ -18,4 +18,5 @@ env STACKDRIVER_PROJECT_ID=<myproject> ./bazel-bin/examples/trace/gcp_exporter/e
 # Results
 
 These are the exported traces as viewed on GCP:
+
 ![image](https://user-images.githubusercontent.com/31712484/86039505-5d347100-b9f7-11ea-865c-0e9bcf9894b8.png)

--- a/examples/trace/gcp_exporter/README.md
+++ b/examples/trace/gcp_exporter/README.md
@@ -14,3 +14,8 @@ After building the example, run the following command but set your Google Projec
 ```
 env STACKDRIVER_PROJECT_ID=<myproject> ./bazel-bin/examples/trace/gcp_exporter/example_simple
 ```
+
+# Results
+
+These are the exported traces as viewed on GCP:
+![image](https://user-images.githubusercontent.com/31712484/86039505-5d347100-b9f7-11ea-865c-0e9bcf9894b8.png)

--- a/examples/trace/gcp_exporter/README.md
+++ b/examples/trace/gcp_exporter/README.md
@@ -1,0 +1,15 @@
+# Simple GCP Trace Exporter Example
+
+In this example, the application in main.cc initializes and registers a tracer provider from the OpenTelemetry SDK. The application then calls a foo_library which has been instrumented using the OpenTelemetry API.
+Resulting telemetry is exported to a user specified Google Cloud project.  
+
+# Building
+To build the example above, simple run the following command:
+```
+bazel build //examples/trace/gcp_exporter:example_simple
+
+# Running
+After building the example, run the following command but set your Google Project ID:
+```
+env STACKDRIVER_PROJECT_ID=<myproject> ./bazel-bin/examples/trace/gcp_exporter/example_simple
+```

--- a/examples/trace/gcp_exporter/README.md
+++ b/examples/trace/gcp_exporter/README.md
@@ -7,6 +7,7 @@ Resulting telemetry is exported to a user specified Google Cloud project.
 To build the example above, simple run the following command:
 ```
 bazel build //examples/trace/gcp_exporter:example_simple
+```
 
 # Running
 After building the example, run the following command but set your Google Project ID:

--- a/examples/trace/gcp_exporter/foo_library/foo_library.cc
+++ b/examples/trace/gcp_exporter/foo_library/foo_library.cc
@@ -1,0 +1,33 @@
+#include "opentelemetry/trace/provider.h"
+
+namespace trace = opentelemetry::trace;
+namespace nostd = opentelemetry::nostd;
+
+namespace
+{
+nostd::shared_ptr<trace::Tracer> get_tracer()
+{
+  auto provider = trace::Provider::GetTracerProvider();
+  return provider->GetTracer("foo_library");
+}
+
+void f1()
+{
+  auto span = get_tracer()->StartSpan("f1");
+}
+
+void f2()
+{
+  auto span = get_tracer()->StartSpan("f2");
+
+  f1();
+  f1();
+}
+}  // namespace
+
+void foo_library()
+{
+  auto span = get_tracer()->StartSpan("library");
+
+  f2();
+}

--- a/examples/trace/gcp_exporter/foo_library/foo_library.h
+++ b/examples/trace/gcp_exporter/foo_library/foo_library.h
@@ -1,0 +1,3 @@
+#pragma once
+
+void foo_library();

--- a/examples/trace/gcp_exporter/main.cc
+++ b/examples/trace/gcp_exporter/main.cc
@@ -1,0 +1,26 @@
+#include "exporters/trace/gcp_exporter/gcp_exporter.h"
+#include "opentelemetry/sdk/trace/simple_processor.h"
+#include "opentelemetry/sdk/trace/tracer_provider.h"
+#include "opentelemetry/trace/provider.h"
+#include "foo_library/foo_library.h"
+
+namespace
+{
+void initTracer()
+{
+  auto exporter  = std::unique_ptr<opentelemetry::sdk::trace::SpanExporter>(new opentelemetry::exporter::gcp::GcpExporter);
+  auto processor = std::shared_ptr<opentelemetry::sdk::trace::SpanProcessor>(
+      new opentelemetry::sdk::trace::SimpleSpanProcessor(std::move(exporter)));
+  auto provider = opentelemetry::nostd::shared_ptr<opentelemetry::trace::TracerProvider>(new opentelemetry::sdk::trace::TracerProvider(processor));
+  // Set the global trace provider
+  opentelemetry::trace::Provider::SetTracerProvider(provider);
+}
+}  // namespace
+
+int main()
+{
+  // Removing this line will leave the default noop TracerProvider in place.
+  initTracer();
+
+  foo_library();
+}

--- a/exporters/trace/gcp_exporter/BUILD
+++ b/exporters/trace/gcp_exporter/BUILD
@@ -15,7 +15,6 @@ cc_library(
         "@com_github_grpc_grpc//:grpc++",
         "@com_google_googleapis//google/devtools/cloudtrace/v2:cloudtrace_cc_grpc",
         "@com_google_googleapis//google/devtools/cloudtrace/v2:cloudtrace_cc_proto",
-        "@com_google_googletest//:gtest_prod"
     ],
 )
 

--- a/exporters/trace/gcp_exporter/BUILD
+++ b/exporters/trace/gcp_exporter/BUILD
@@ -1,0 +1,34 @@
+licenses(["notice"])  # Apache License 2.0
+
+package(default_visibility = ["//visibility:public"])
+
+# Libraries
+# ========================================================================= #
+cc_library(
+    name = "gcp_exporter",
+    srcs = ["internal/gcp_exporter.cc"],
+    hdrs = ["gcp_exporter.h"],
+    deps = [
+        "@io_opentelemetry_cpp//api",
+        "@io_opentelemetry_cpp//sdk/src/trace",
+        "@io_opentelemetry_cpp//sdk/src/common:random",
+        "@com_github_grpc_grpc//:grpc++",
+        "@com_google_googleapis//google/devtools/cloudtrace/v2:cloudtrace_cc_grpc",
+        "@com_google_googleapis//google/devtools/cloudtrace/v2:cloudtrace_cc_proto",
+        "@com_google_googletest//:gtest_prod"
+    ],
+)
+
+# Tests
+# ========================================================================= #
+
+cc_test(
+    name = "gcp_exporter_test",
+    srcs = ["internal/gcp_exporter_test.cc"],
+    deps = [
+        ":gcp_exporter",
+        "@io_opentelemetry_cpp//sdk/src/trace",
+        "@io_opentelemetry_cpp//api",
+        "@com_google_googletest//:gtest_main"
+    ],
+)

--- a/exporters/trace/gcp_exporter/README.md
+++ b/exporters/trace/gcp_exporter/README.md
@@ -1,0 +1,1 @@
+# GCP Exporter

--- a/exporters/trace/gcp_exporter/README.md
+++ b/exporters/trace/gcp_exporter/README.md
@@ -1,1 +1,0 @@
-# GCP Exporter

--- a/exporters/trace/gcp_exporter/gcp_exporter.h
+++ b/exporters/trace/gcp_exporter/gcp_exporter.h
@@ -4,7 +4,6 @@
 #include "opentelemetry/sdk/trace/span_data.h"
 #include "google/devtools/cloudtrace/v2/tracing.grpc.pb.h"
 #include "src/common/random.h"
-#include "gtest/gtest_prod.h"
 
 #include <iostream>
 #include <functional>
@@ -13,8 +12,10 @@
 
 
 OPENTELEMETRY_BEGIN_NAMESPACE
-namespace exporter {
-namespace gcp {
+namespace exporter 
+{
+namespace gcp 
+{
 
 /**
  * This class handles all the functionality of exporting traces to Google Cloud
@@ -36,31 +37,34 @@ public:
      * Exports all gathered spans to the cloud
      * 
      * @param spans - List of spans to export to google cloud
-     * @returns Success or failure based on returned gRPC status 
+     * @return Success or failure based on returned gRPC status 
      */
     sdk::trace::ExportResult Export(const nostd::span<std::unique_ptr<sdk::trace::Recordable>> &spans) noexcept;
 
-    /* Test Class meant for testing purposes only */
-    friend class GcpExporterTestPeer;
+    /**/
+    void Shutdown(std::chrono::microseconds timeout = std::chrono::microseconds(0)) noexcept {}
 
 private:
+     /* Test Class meant for testing purposes only */
+    friend class GcpExporterTestPeer;
+
     /**
      * Internal constructor to initialize trace id and the RPC communication stub
      * Helps with testing purposes by injecting a mock stub
+     * 
+     * @param stub - The stub to inject into the member variable 'trace_service_stub_'
+     * @param trace_id - The randomly generated trace id for the current trace
      */
-    GcpExporter(google::devtools::cloudtrace::v2::TraceService::StubInterface* stub,
-                const trace::TraceId trace_id);
-
-    /* NOTE: This is subject to change as currently we have no parent context for a span in OT */
-    trace::TraceId trace_id_;
+    explicit GcpExporter(std::unique_ptr<google::devtools::cloudtrace::v2::TraceService::StubInterface> stub,
+                         const trace::TraceId trace_id);
 
     /* The stub to communicate via gRPC to the Google cloud */
-    std::unique_ptr<google::devtools::cloudtrace::v2::TraceService::StubInterface> trace_service_stub{nullptr};
+    const std::unique_ptr<google::devtools::cloudtrace::v2::TraceService::StubInterface> trace_service_stub_;
 
-    /**/
-    void Shutdown(std::chrono::microseconds timeout = std::chrono::microseconds(0)) noexcept {}
+    /* NOTE: This is subject to change as currently we have no parent context for a span in OT */
+    const trace::TraceId trace_id_;
 };
 
 } // gcp
-} // exporters
+} // exporter
 OPENTELEMETRY_END_NAMESPACE

--- a/exporters/trace/gcp_exporter/gcp_exporter.h
+++ b/exporters/trace/gcp_exporter/gcp_exporter.h
@@ -1,0 +1,66 @@
+#pragma once
+
+#include "opentelemetry/sdk/trace/exporter.h"
+#include "opentelemetry/sdk/trace/span_data.h"
+#include "google/devtools/cloudtrace/v2/tracing.grpc.pb.h"
+#include "src/common/random.h"
+#include "gtest/gtest_prod.h"
+
+#include <iostream>
+#include <functional>
+#include <memory>
+#include <string>
+
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace exporter {
+namespace gcp {
+
+/**
+ * This class handles all the functionality of exporting traces to Google Cloud
+ */
+class GcpExporter final : public sdk::trace::SpanExporter
+{
+public:
+    /**
+     * Class Constructor which invokes all the register/initialization functions
+     */
+    GcpExporter();
+
+    /**
+     * Creates a Recordable(Span) object
+     */
+    std::unique_ptr<sdk::trace::Recordable> MakeRecordable() noexcept;
+
+    /**
+     * Exports all gathered spans to the cloud
+     * 
+     * @param spans - List of spans to export to google cloud
+     * @returns Success or failure based on returned gRPC status 
+     */
+    sdk::trace::ExportResult Export(const nostd::span<std::unique_ptr<sdk::trace::Recordable>> &spans) noexcept;
+
+    /* Test Class meant for testing purposes only */
+    friend class GcpExporterTestPeer;
+
+private:
+    /**
+     * Internal constructor to initialize trace id and the RPC communication stub
+     * Helps with testing purposes by injecting a mock stub
+     */
+    GcpExporter(google::devtools::cloudtrace::v2::TraceService::StubInterface* stub,
+                const trace::TraceId trace_id);
+
+    /* NOTE: This is subject to change as currently we have no parent context for a span in OT */
+    trace::TraceId trace_id_;
+
+    /* The stub to communicate via gRPC to the Google cloud */
+    std::unique_ptr<google::devtools::cloudtrace::v2::TraceService::StubInterface> trace_service_stub{nullptr};
+
+    /**/
+    void Shutdown(std::chrono::microseconds timeout = std::chrono::microseconds(0)) noexcept {}
+};
+
+} // gcp
+} // exporters
+OPENTELEMETRY_END_NAMESPACE

--- a/exporters/trace/gcp_exporter/internal/gcp_exporter.cc
+++ b/exporters/trace/gcp_exporter/internal/gcp_exporter.cc
@@ -1,0 +1,208 @@
+#include "../gcp_exporter.h"
+#include <stdlib.h>
+#include <grpcpp/grpcpp.h>
+#include "opentelemetry/trace/trace_id.h"
+#include "opentelemetry/trace/span_id.h"
+#include "google/protobuf/timestamp.pb.h"
+
+constexpr char kGoogleTraceAddress[] = "cloudtrace.googleapis.com";
+constexpr int kByteSizeSpanId = 16;
+constexpr int kByteSizeTraceId = 32;
+constexpr char kProjectsPathStr[] = "projects/";
+constexpr char kTracesPathStr[] = "/traces/";
+constexpr char kSpansPathStr[] = "/spans/";
+
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace exporter {
+namespace gcp {
+
+
+/* ######################## HELPER FUNCTIONS ######################### */
+
+/**
+ * Generates a random trace id
+ * NOTE: This is subject to change in the future and will be moved to 
+ *       sdk/src/trace/span.cc
+ */
+trace::TraceId GenerateRandomTraceId() 
+{
+    uint8_t trace_id_buf[trace::TraceId::kSize];
+    opentelemetry::sdk::common::Random::GenerateRandomBuffer(trace_id_buf);
+    return trace::TraceId(trace_id_buf);
+}
+
+
+/**
+ * Generates a random span id
+ * NOTE: This is subject to change in the future and will be moved to 
+ *       sdk/src/trace/span.cc
+ */
+trace::SpanId GenerateRandomSpanId()
+{
+    uint8_t span_id_buf[trace::SpanId::kSize];
+    opentelemetry::sdk::common::Random::GenerateRandomBuffer(span_id_buf);
+    return trace::SpanId(span_id_buf);
+}
+
+
+/**
+ * Sets google protobuf object's unix start time, both seconds and nanos
+ * 
+ * @param from_span - The span whose start time we extract and convert to google protobuf timestamp
+ * @param proto - A google protobuf timestamp whose seconds and nanoseconds we set in unix time 
+ */
+void SetStartTimestamp(const sdk::trace::SpanData* from_span, google::protobuf::Timestamp* proto)
+{
+    std::chrono::nanoseconds unix_time_nanoseconds(from_span->GetStartTime().time_since_epoch().count());
+    auto time_in_seconds = std::chrono::duration_cast<std::chrono::seconds>(unix_time_nanoseconds);
+    proto->set_seconds(time_in_seconds.count());
+    auto time_in_nanoseconds = std::chrono::duration_cast<std::chrono::nanoseconds>(time_in_seconds);
+    proto->set_nanos(unix_time_nanoseconds.count()-time_in_nanoseconds.count());
+}
+
+
+/**
+ * Sets google protobuf object's unix end time, both seconds and nanos
+ * 
+ * @param from_span - The span whose end time we extract and convert to google protobuf timestamp
+ * @param proto - A google protobuf timestamp whose seconds and nanoseconds we set in unix time
+ */
+void SetEndTimestamp(const sdk::trace::SpanData* from_span, google::protobuf::Timestamp* proto)
+{
+    std::chrono::nanoseconds unix_time_nanoseconds(from_span->GetStartTime().time_since_epoch().count()
+                                                    + from_span->GetDuration().count());
+    auto time_in_seconds = std::chrono::duration_cast<std::chrono::seconds>(unix_time_nanoseconds);
+    proto->set_seconds(time_in_seconds.count());
+    auto time_in_nanoseconds = std::chrono::duration_cast<std::chrono::nanoseconds>(time_in_seconds);
+    proto->set_nanos(unix_time_nanoseconds.count()-time_in_nanoseconds.count());
+}
+
+
+/**
+ * Converts each Recordable(Span) to a google protobuf span used by Cloud Trace v2 API
+ * to display traces on GCP
+ * 
+ * @param spans - The list of spans to be exported to google cloud
+ * @param project_id - User specified google cloud project id
+ * @param trace_id_ - *This is subject to change in the future*
+ * @param request - The request we send via gRPC to the cloud to export the traces
+ */
+void ConvertSpans(const nostd::span<std::unique_ptr<sdk::trace::Recordable>> &spans,
+                  const std::string& project_id,
+                  const trace::TraceId& trace_id_,
+                  google::devtools::cloudtrace::v2::BatchWriteSpansRequest* request)
+{
+
+    for (auto &recordable : spans)
+    {
+        auto to_span = request->add_spans();
+        auto from_span = std::unique_ptr<sdk::trace::SpanData>(
+            static_cast<sdk::trace::SpanData *>(recordable.release()));
+
+        /*                      SET SPAN DATA                      */
+
+        // Generate random span id 
+        // NOTE: This is subject to change in the future and will be moved to 
+        //       sdk/src/trace/span.cc
+        auto span_id = GenerateRandomSpanId();
+        
+        // NOTE: This implementation of trace id is subject to change in the future once parent 
+        //       context is available for a span, wherein we can just retrieve trace id from the parent
+        // Convert bytes to hex
+        std::array<char, kByteSizeTraceId> hex_trace_buf; trace_id_.ToLowerBase16(hex_trace_buf);
+        std::string hex_trace(hex_trace_buf.data(), kByteSizeTraceId);
+        std::array<char, kByteSizeSpanId> hex_span_buf; span_id.ToLowerBase16(hex_span_buf);
+        std::string hex_span(hex_span_buf.data(), kByteSizeSpanId);
+        
+        // Set span id
+        to_span->set_span_id(hex_span);
+
+        // Set names
+        to_span->set_name(kProjectsPathStr + project_id + kTracesPathStr + hex_trace + kSpansPathStr + hex_span);
+        to_span->mutable_display_name()->set_value(std::string(from_span->GetName()));
+        
+        // set start time
+        SetStartTimestamp(from_span.get(), to_span->mutable_start_time());
+
+        // set end time
+        SetEndTimestamp(from_span.get(), to_span->mutable_end_time());
+
+        // TODO:
+        // Get other features of the span once more data is added to the official repo
+    }
+}
+
+
+/* ################### INITIALIZATION/REGISTER FUNCTIONS ########################## */
+
+/**
+ * Establishes gRPC communication channel to the Google Trace Address
+ * 
+ * @return A cloudtrace v2 API trace service stub to communicate over via gRPC
+ */
+std::unique_ptr<google::devtools::cloudtrace::v2::TraceService::Stub> MakeServiceStub()
+{
+    grpc::ChannelArguments args;
+    args.SetUserAgentPrefix("opentelemetry-cpp/" OPENTELEMETRY_VERSION);
+    auto channel = grpc::CreateCustomChannel(kGoogleTraceAddress, 
+                                            grpc::GoogleDefaultCredentials(),
+                                            args);
+    return google::devtools::cloudtrace::v2::TraceService::NewStub(channel);
+}
+
+
+GcpExporter::GcpExporter()
+{
+    auto trace_service_stub = MakeServiceStub();
+    auto trace_id = GenerateRandomTraceId();
+    GcpExporter(trace_service_stub.release(), trace_id);
+}
+
+GcpExporter::GcpExporter(google::devtools::cloudtrace::v2::TraceService::StubInterface* stub,
+                         trace::TraceId trace_id)
+{
+    trace_service_stub = std::unique_ptr<google::devtools::cloudtrace::v2::TraceService::StubInterface>(stub);
+    trace_id_ = trace_id;
+}
+
+/* ############################### EXPORT FUNCTIONS ################################## */
+
+
+std::unique_ptr<sdk::trace::Recordable> GcpExporter::MakeRecordable() noexcept
+{
+    return std::unique_ptr<sdk::trace::Recordable>(new sdk::trace::SpanData);
+}
+
+
+sdk::trace::ExportResult GcpExporter::Export(
+      const nostd::span<std::unique_ptr<sdk::trace::Recordable>> &spans) noexcept 
+{
+    // Fetch project id
+    const std::string project_id(getenv("GOOGLE_CLOUD_PROJECT_ID"));
+
+    // Set up gRPC request
+    google::devtools::cloudtrace::v2::BatchWriteSpansRequest request;
+    request.set_name("projects/" + project_id);
+
+    // Convert recordables to google protobufs
+    ConvertSpans(spans, project_id, trace_id_, &request);
+
+    google::protobuf::Empty response;
+    grpc::ClientContext context;
+
+    // Send the RPC
+    grpc::Status status = trace_service_stub->BatchWriteSpans(&context, request, &response);
+
+    // Check status and return results
+    if(status.ok()){
+        return sdk::trace::ExportResult::kSuccess;
+    } else {
+        return sdk::trace::ExportResult::kFailure;
+    }
+}
+
+} // gcp
+} // exporter
+OPENTELEMETRY_END_NAMESPACE
+

--- a/exporters/trace/gcp_exporter/internal/gcp_exporter_test.cc
+++ b/exporters/trace/gcp_exporter/internal/gcp_exporter_test.cc
@@ -1,0 +1,107 @@
+#include "gtest/gtest.h"
+#include <stdlib.h>
+#include "../gcp_exporter.h"
+#include "opentelemetry/sdk/trace/simple_processor.h"
+#include "opentelemetry/sdk/trace/tracer_provider.h"
+#include "opentelemetry/trace/provider.h"
+#include "opentelemetry/core/timestamp.h"
+#include "google/devtools/cloudtrace/v2/tracing_mock.grpc.pb.h"
+
+using namespace testing;
+using grpc::Status;
+
+constexpr int kByteSizeTraceId = 32;
+namespace gcp = opentelemetry::exporter::gcp;
+namespace cloudtrace_v2 = google::devtools::cloudtrace::v2;
+
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace exporter {
+namespace gcp {
+
+class GcpExporterTestPeer : public ::testing::Test
+{
+public:
+    virtual void SetUp()
+    {
+        // Set GOOGLE_CLOUD_PROJECT_ID environment variable
+        setenv("GOOGLE_CLOUD_PROJECT_ID", "mock_project", 1);
+    }
+
+    std::unique_ptr<GcpExporter> GetExporter(google::devtools::cloudtrace::v2::TraceService::StubInterface* mock_stub) 
+    {
+            return std::unique_ptr<GcpExporter>(new GcpExporter(mock_stub, GenerateRandomTraceId()));
+    }
+
+private:
+    trace::TraceId GenerateRandomTraceId() 
+    {
+        uint8_t trace_id_buf[trace::TraceId::kSize];
+        opentelemetry::sdk::common::Random::GenerateRandomBuffer(trace_id_buf);
+        return trace::TraceId(trace_id_buf);
+    }
+
+};
+
+
+TEST_F(GcpExporterTestPeer, TestGeneralFunctionality)
+{
+    // Set up mock stub
+    auto mock_stub = new cloudtrace_v2::MockTraceServiceStub();
+    EXPECT_CALL(*mock_stub, BatchWriteSpans(_,_,_)).Times(AtLeast(1)).WillRepeatedly(Return(Status::OK));
+
+    auto gcp_exporter  = std::unique_ptr<sdk::trace::SpanExporter>(GetExporter(mock_stub));
+    auto processor = std::shared_ptr<sdk::trace::SpanProcessor>(new sdk::trace::SimpleSpanProcessor(std::move(gcp_exporter)));
+    auto provider = nostd::shared_ptr<trace::TracerProvider>(new sdk::trace::TracerProvider(processor));
+    
+    auto tracer = provider->GetTracer("Test Export");
+
+    auto span = tracer->StartSpan("Test Span");
+
+    auto span_1 = tracer->StartSpan("Span 1");
+    auto span_1_1 = tracer->StartSpan("Span 1.1");
+    auto span_1_1_1 = tracer->StartSpan("Span 1.1.1");
+    span_1_1_1->End();
+    span_1_1->End();
+    span_1->End();
+
+    auto span_2 = tracer->StartSpan("Span 2");
+    auto span_2_1 = tracer->StartSpan("Span 2.1");
+    span_2_1->End();
+    auto span_2_2 = tracer->StartSpan("Span 2.2");
+    span_2_2->End();
+    span_2->End();
+
+    span->End();
+}
+
+
+
+TEST_F(GcpExporterTestPeer, TestExportResults)
+{
+    // Set up mock stub
+    auto mock_stub = new cloudtrace_v2::MockTraceServiceStub();
+    auto gcp_exporter  = std::unique_ptr<sdk::trace::SpanExporter>(GetExporter(mock_stub));
+
+    // Make sample recordables
+    auto recordable_1 = gcp_exporter->MakeRecordable();
+    recordable_1->SetName("Sample span 1");
+    auto recordable_2 = gcp_exporter->MakeRecordable();
+    recordable_2->SetName("Sample span 2");
+    
+    // Test Success
+    EXPECT_CALL(*mock_stub, BatchWriteSpans(_,_,_)).Times(1).WillOnce(Return(Status::OK));
+    nostd::span<std::unique_ptr<sdk::trace::Recordable>> batch_1(&recordable_1, 1);
+    auto result_1 = gcp_exporter->Export(batch_1);
+    EXPECT_EQ(sdk::trace::ExportResult::kSuccess, result_1);
+
+    // Test Failure
+    EXPECT_CALL(*mock_stub, BatchWriteSpans(_,_,_)).Times(1).WillOnce(Return(Status::CANCELLED));
+    nostd::span<std::unique_ptr<sdk::trace::Recordable>> batch_2(&recordable_2, 1);
+    auto result_2 = gcp_exporter->Export(batch_2);
+    EXPECT_EQ(sdk::trace::ExportResult::kFailure, result_2);
+}
+
+} // gcp
+} // exporters
+OPENTELEMETRY_END_NAMESPACE


### PR DESCRIPTION
This PR contains a minimal version of the C++ GCP exporter for OT.
Currently, there are some missing fields for a Span (some links and other resources) that have not been implemented yet for OT.

Thus, we only have a few fields to fill for the google protobuf object, namely StartTime, EndTime, Name, DisplayName, SpanID and TraceID.

This exporter will later be transferred to its own separate repo under the Google Cloud Platform organization.