### PR TITLE
Extended SetAttribute() method to include all integer types

### DIFF
--- a/exporters/trace/gcp_exporter/internal/recordable.cc
+++ b/exporters/trace/gcp_exporter/internal/recordable.cc
@@ -36,7 +36,7 @@ void Recordable::SetAttribute(nostd::string_view key,
                               const common::AttributeValue &value) noexcept
 {
     // Get the protobuf span's map
-    auto map = span_.mutable_attributes()->mutable_attribute_map();
+    auto* map = span_.mutable_attributes()->mutable_attribute_map();
 
     if(nostd::holds_alternative<bool>(value))
     {

--- a/exporters/trace/gcp_exporter/internal/recordable.cc
+++ b/exporters/trace/gcp_exporter/internal/recordable.cc
@@ -40,33 +40,33 @@ void Recordable::SetAttribute(nostd::string_view key,
 
     if(nostd::holds_alternative<bool>(value))
     {
-        (*map)[std::string(key)].set_bool_value(nostd::get<bool>(value));
+        (*map)[key.data()].set_bool_value(nostd::get<bool>(value));
     } 
     else if (nostd::holds_alternative<int>(value))
     {
-        (*map)[std::string(key)].set_int_value(nostd::get<int>(value));
+        (*map)[key.data()].set_int_value(nostd::get<int>(value));
     }
     else if (nostd::holds_alternative<int64_t>(value))
     {
-        (*map)[std::string(key)].set_int_value(nostd::get<int64_t>(value));
+        (*map)[key.data()].set_int_value(nostd::get<int64_t>(value));
     }
     else if (nostd::holds_alternative<unsigned int>(value))
     {
-        (*map)[std::string(key)].set_int_value(nostd::get<unsigned int>(value));
+        (*map)[key.data()].set_int_value(nostd::get<unsigned int>(value));
     }
     else if (nostd::holds_alternative<uint64_t>(value))
     {
-        (*map)[std::string(key)].set_int_value(nostd::get<uint64_t>(value));
+        (*map)[key.data()].set_int_value(nostd::get<uint64_t>(value));
     }
     else if (nostd::holds_alternative<int64_t>(value))
     {
-        (*map)[std::string(key)].set_int_value(nostd::get<int64_t>(value));
+        (*map)[key.data()].set_int_value(nostd::get<int64_t>(value));
     } 
     else if (nostd::holds_alternative<nostd::string_view>(value))
     {
         // TODO: Truncate string to 128 bytes
         std::string value_str = std::string(nostd::get<nostd::string_view>(value));
-        (*map)[std::string(key)].mutable_string_value()->set_value(value_str);
+        (*map)[key.data()].mutable_string_value()->set_value(value_str);
     }
 }
 

--- a/exporters/trace/gcp_exporter/internal/recordable.cc
+++ b/exporters/trace/gcp_exporter/internal/recordable.cc
@@ -1,5 +1,4 @@
 #include "exporters/trace/gcp_exporter/recordable.h"
-#include <assert.h>
 
 
 OPENTELEMETRY_BEGIN_NAMESPACE
@@ -34,7 +33,7 @@ void Recordable::SetIds(trace::TraceId trace_id,
 
 
 void Recordable::SetAttribute(nostd::string_view key,
-                              const common::AttributeValue &&value) noexcept
+                              const common::AttributeValue &value) noexcept
 {
     // Get the protobuf span's map
     auto map = span_.mutable_attributes()->mutable_attribute_map();
@@ -43,6 +42,22 @@ void Recordable::SetAttribute(nostd::string_view key,
     {
         (*map)[std::string(key)].set_bool_value(nostd::get<bool>(value));
     } 
+    else if (nostd::holds_alternative<int>(value))
+    {
+        (*map)[std::string(key)].set_int_value(nostd::get<int>(value));
+    }
+    else if (nostd::holds_alternative<int64_t>(value))
+    {
+        (*map)[std::string(key)].set_int_value(nostd::get<int64_t>(value));
+    }
+    else if (nostd::holds_alternative<unsigned int>(value))
+    {
+        (*map)[std::string(key)].set_int_value(nostd::get<unsigned int>(value));
+    }
+    else if (nostd::holds_alternative<uint64_t>(value))
+    {
+        (*map)[std::string(key)].set_int_value(nostd::get<uint64_t>(value));
+    }
     else if (nostd::holds_alternative<int64_t>(value))
     {
         (*map)[std::string(key)].set_int_value(nostd::get<int64_t>(value));
@@ -56,9 +71,22 @@ void Recordable::SetAttribute(nostd::string_view key,
 }
 
 
-void Recordable::AddEvent(nostd::string_view name, core::SystemTimestamp timestamp) noexcept
+void Recordable::AddEvent(nostd::string_view name, 
+                          core::SystemTimestamp timestamp,
+                          const opentelemetry::trace::KeyValueIterable &attributes) noexcept
 {
     (void)name;
+    (void)timestamp;
+    (void)attributes;
+}
+
+
+void Recordable::AddLink(
+      opentelemetry::trace::SpanContext span_context,
+      const opentelemetry::trace::KeyValueIterable &attributes) noexcept
+{
+    (void)span_context;
+    (void)attributes;
 }
 
 

--- a/exporters/trace/gcp_exporter/internal/recordable_test.cc
+++ b/exporters/trace/gcp_exporter/internal/recordable_test.cc
@@ -16,11 +16,29 @@ TEST(Recordable, TestSetAttribute)
     const common::AttributeValue bool_value = true;
     rec.SetAttribute(bool_key, std::move(bool_value));
 
-    // Set 'integer' type
+    // Set 'int' type
     const nostd::string_view int_key = "int_key";
-    const int64_t seven = 7;
-    const common::AttributeValue int_value = seven;
+    const int seven_int = 7;
+    const common::AttributeValue int_value = seven_int;
     rec.SetAttribute(int_key, std::move(int_value));
+
+    // Set 'int64_t' type
+    const nostd::string_view int64_t_key = "int64_t_key";
+    const int64_t seven_int64_t = 7;
+    const common::AttributeValue int64_t_value = seven_int64_t;
+    rec.SetAttribute(int64_t_key, std::move(int64_t_value));
+
+    // Set 'uint64_t' type
+    const nostd::string_view uint64_t_key = "uint64_t_key";
+    const uint64_t seven_uint64_t = 7;
+    const common::AttributeValue uint64_t_value = seven_uint64_t;
+    rec.SetAttribute(uint64_t_key, std::move(uint64_t_value));
+
+    // Set 'unsigned int' type
+    const nostd::string_view unsigned_int_key = "unsigned_int_key";
+    const int64_t seven_unsigned_int = 7;
+    const common::AttributeValue unsigned_int_value = seven_unsigned_int;
+    rec.SetAttribute(unsigned_int_key, std::move(unsigned_int_value));
 
     // Set 'string' type
     const nostd::string_view string_key = "string_key";
@@ -30,7 +48,10 @@ TEST(Recordable, TestSetAttribute)
     auto attr_map = rec.span().attributes().attribute_map();
     
     EXPECT_TRUE(attr_map["bool_key"].bool_value());
-    EXPECT_EQ(seven, attr_map["int_key"].int_value());
+    EXPECT_EQ(seven_int, attr_map["int_key"].int_value());
+    EXPECT_EQ(seven_uint64_t, attr_map["uint64_t_key"].int_value());
+    EXPECT_EQ(seven_int64_t, attr_map["int64_t_key"].int_value());
+    EXPECT_EQ(seven_unsigned_int, attr_map["unsigned_int_key"].int_value());
     EXPECT_EQ("test", attr_map["string_key"].string_value().value());
 }
 

--- a/exporters/trace/gcp_exporter/internal/recordable_test.cc
+++ b/exporters/trace/gcp_exporter/internal/recordable_test.cc
@@ -7,7 +7,7 @@ namespace exporter
 namespace gcp
 {
 
-TEST(Recordable, TestSetAttribute)
+TEST(Recordable, TestSetNonIntAttribute)
 {
     Recordable rec;
 
@@ -15,30 +15,6 @@ TEST(Recordable, TestSetAttribute)
     const nostd::string_view bool_key = "bool_key";
     const common::AttributeValue bool_value = true;
     rec.SetAttribute(bool_key, std::move(bool_value));
-
-    // Set 'int' type
-    const nostd::string_view int_key = "int_key";
-    const int seven_int = 7;
-    const common::AttributeValue int_value = seven_int;
-    rec.SetAttribute(int_key, std::move(int_value));
-
-    // Set 'int64_t' type
-    const nostd::string_view int64_t_key = "int64_t_key";
-    const int64_t seven_int64_t = 7;
-    const common::AttributeValue int64_t_value = seven_int64_t;
-    rec.SetAttribute(int64_t_key, std::move(int64_t_value));
-
-    // Set 'uint64_t' type
-    const nostd::string_view uint64_t_key = "uint64_t_key";
-    const uint64_t seven_uint64_t = 7;
-    const common::AttributeValue uint64_t_value = seven_uint64_t;
-    rec.SetAttribute(uint64_t_key, std::move(uint64_t_value));
-
-    // Set 'unsigned int' type
-    const nostd::string_view unsigned_int_key = "unsigned_int_key";
-    const int64_t seven_unsigned_int = 7;
-    const common::AttributeValue unsigned_int_value = seven_unsigned_int;
-    rec.SetAttribute(unsigned_int_key, std::move(unsigned_int_value));
 
     // Set 'string' type
     const nostd::string_view string_key = "string_key";
@@ -48,11 +24,30 @@ TEST(Recordable, TestSetAttribute)
     auto attr_map = rec.span().attributes().attribute_map();
     
     EXPECT_TRUE(attr_map["bool_key"].bool_value());
-    EXPECT_EQ(seven_int, attr_map["int_key"].int_value());
-    EXPECT_EQ(seven_uint64_t, attr_map["uint64_t_key"].int_value());
-    EXPECT_EQ(seven_int64_t, attr_map["int64_t_key"].int_value());
-    EXPECT_EQ(seven_unsigned_int, attr_map["unsigned_int_key"].int_value());
     EXPECT_EQ("test", attr_map["string_key"].string_value().value());
+}
+
+template <typename T>
+struct IntAttributeTest : public testing::Test
+{
+    using IntParamType = T;
+};
+
+using IntTypes = testing::Types<int, int64_t, unsigned int, uint64_t>;
+TYPED_TEST_CASE(IntAttributeTest, IntTypes);
+
+TYPED_TEST(IntAttributeTest, SetIntSingleAttribute)
+{
+    using IntType = typename TestFixture::IntParamType;
+    IntType i     = 2;
+    common::AttributeValue int_val(i);
+
+    Recordable rec;
+    rec.SetAttribute("int_key", int_val);
+
+    auto attr_map = rec.span().attributes().attribute_map();
+
+    EXPECT_EQ(nostd::get<IntType>(int_val), attr_map["int_key"].int_value());
 }
 
 TEST(Recordable, TestSetIds)

--- a/exporters/trace/gcp_exporter/recordable.h
+++ b/exporters/trace/gcp_exporter/recordable.h
@@ -22,16 +22,26 @@ class Recordable final : public sdk::trace::Recordable
 public:
   const google::devtools::cloudtrace::v2::Span &span() const noexcept { return span_; }
 
-  void SetIds(trace::TraceId trace_id,
-              trace::SpanId span_id,
-              trace::SpanId parent_span_id) noexcept override;
+  void SetIds(opentelemetry::trace::TraceId trace_id,
+                      opentelemetry::trace::SpanId span_id,
+                      opentelemetry::trace::SpanId parent_span_id) noexcept override;
 
   void SetAttribute(nostd::string_view key,
-                    const opentelemetry::common::AttributeValue &&value) noexcept override;
+                            const opentelemetry::common::AttributeValue &value) noexcept override;
 
-  void AddEvent(nostd::string_view name, core::SystemTimestamp timestamp) noexcept override;
+  void AddEvent(
+      nostd::string_view name,
+      core::SystemTimestamp timestamp = core::SystemTimestamp(std::chrono::system_clock::now()),
+      const opentelemetry::trace::KeyValueIterable &attributes =
+          opentelemetry::trace::KeyValueIterableView<std::map<std::string, int>>({})) noexcept override;
 
-  void SetStatus(trace::CanonicalCode code, nostd::string_view description) noexcept override;
+  void AddLink(
+      opentelemetry::trace::SpanContext span_context,
+      const opentelemetry::trace::KeyValueIterable &attributes =
+          opentelemetry::trace::KeyValueIterableView<std::map<std::string, int>>({})) noexcept override;
+
+  void SetStatus(opentelemetry::trace::CanonicalCode code,
+                         nostd::string_view description) noexcept override;
 
   void SetName(nostd::string_view name) noexcept override;
 

--- a/exporters/trace/gcp_exporter/recordable.h
+++ b/exporters/trace/gcp_exporter/recordable.h
@@ -31,14 +31,12 @@ public:
 
   void AddEvent(
       nostd::string_view name,
-      core::SystemTimestamp timestamp = core::SystemTimestamp(std::chrono::system_clock::now()),
-      const opentelemetry::trace::KeyValueIterable &attributes =
-          opentelemetry::trace::KeyValueIterableView<std::map<std::string, int>>({})) noexcept override;
+      core::SystemTimestamp timestamp,
+      const opentelemetry::trace::KeyValueIterable &attributes) noexcept override;
 
   void AddLink(
       opentelemetry::trace::SpanContext span_context,
-      const opentelemetry::trace::KeyValueIterable &attributes =
-          opentelemetry::trace::KeyValueIterableView<std::map<std::string, int>>({})) noexcept override;
+      const opentelemetry::trace::KeyValueIterable &attributes) noexcept override;
 
   void SetStatus(opentelemetry::trace::CanonicalCode code,
                          nostd::string_view description) noexcept override;


### PR DESCRIPTION
Added code to cover all integer types for the GCP recordable.
Added test coverage for the same.