### PR TITLE
Update code to compile with latest verson of OtelCpp

### DIFF
--- a/examples/trace/gcp_exporter/foo_library/foo_library.cc
+++ b/examples/trace/gcp_exporter/foo_library/foo_library.cc
@@ -1,5 +1,4 @@
 #include "opentelemetry/trace/provider.h"
-#include "opentelemetry/context/threadlocal_context.h"
 
 namespace trace = opentelemetry::trace;
 namespace nostd = opentelemetry::nostd;

--- a/exporters/trace/gcp_exporter/internal/recordable.cc
+++ b/exporters/trace/gcp_exporter/internal/recordable.cc
@@ -107,7 +107,7 @@ void Recordable::SetAttribute(nostd::string_view key,
 
 void Recordable::AddEvent(nostd::string_view name, 
                           core::SystemTimestamp timestamp,
-                          const opentelemetry::trace::KeyValueIterable &attributes) noexcept
+                          const opentelemetry::common::KeyValueIterable &attributes) noexcept
 {
     (void)name;
     (void)timestamp;
@@ -115,8 +115,8 @@ void Recordable::AddEvent(nostd::string_view name,
 }
 
 void Recordable::AddLink(
-      opentelemetry::trace::SpanContext span_context,
-      const opentelemetry::trace::KeyValueIterable &attributes) noexcept
+      const opentelemetry::trace::SpanContext &span_context,
+      const opentelemetry::common::KeyValueIterable &attributes) noexcept
 {
     (void)span_context;
     (void)attributes;

--- a/exporters/trace/gcp_exporter/internal/recordable_test.cc
+++ b/exporters/trace/gcp_exporter/internal/recordable_test.cc
@@ -1,5 +1,5 @@
 #include "exporters/trace/gcp_exporter/recordable.h"
-#include "opentelemetry/context/threadlocal_context.h"
+#include "opentelemetry/context/runtime_context.h"
 
 #include <gtest/gtest.h>
 

--- a/exporters/trace/gcp_exporter/recordable.h
+++ b/exporters/trace/gcp_exporter/recordable.h
@@ -32,11 +32,11 @@ public:
   void AddEvent(
       nostd::string_view name,
       core::SystemTimestamp timestamp,
-      const opentelemetry::trace::KeyValueIterable &attributes) noexcept override;
+      const opentelemetry::common::KeyValueIterable &attributes) noexcept override;
 
   void AddLink(
-      opentelemetry::trace::SpanContext span_context,
-      const opentelemetry::trace::KeyValueIterable &attributes) noexcept override;
+      const opentelemetry::trace::SpanContext &span_context,
+      const opentelemetry::common::KeyValueIterable &attributes) noexcept override;
 
   void SetStatus(opentelemetry::trace::CanonicalCode code,
                          nostd::string_view description) noexcept override;


### PR DESCRIPTION
This just brings the project up the latest opentelemetry CPP api.   Tests do NOT pass, things just compile.